### PR TITLE
net: dns: Fix multiple IP DNS resolution

### DIFF
--- a/subsys/net/lib/dns/Kconfig
+++ b/subsys/net/lib/dns/Kconfig
@@ -43,6 +43,14 @@ config DNS_RESOLVER_ADDITIONAL_QUERIES
 	  The maximum value of this variable is constrained to avoid
 	  'alias loops'.
 
+config DNS_RESOLVER_AI_MAX_ENTRIES
+	int "Maximum number of IP addresses for DNS name"
+	default 2
+	help
+	  Defines the max number of IP addresses per domain name
+	  resolution the DNS resolver can handle.
+
+
 config DNS_RESOLVER_MAX_SERVERS
 	int "Number of DNS server addresses"
 	range 1 NET_MAX_CONTEXTS

--- a/subsys/net/lib/dns/dns_pack.c
+++ b/subsys/net/lib/dns/dns_pack.c
@@ -106,7 +106,8 @@ static int skip_fqdn(uint8_t *answer, int buf_sz)
 	return i;
 }
 
-int dns_unpack_answer(struct dns_msg_t *dns_msg, int dname_ptr, uint32_t *ttl)
+int dns_unpack_answer(struct dns_msg_t *dns_msg, int dname_ptr, uint32_t *ttl,
+		      enum dns_rr_type *type)
 {
 	int dname_len;
 	uint16_t rem_size;
@@ -155,8 +156,9 @@ int dns_unpack_answer(struct dns_msg_t *dns_msg, int dname_ptr, uint32_t *ttl)
 		DNS_COMMON_UINT_SIZE + /* type length */
 		DNS_TTL_LEN +
 		DNS_RDLENGTH_LEN;
+	*type = dns_answer_type(dname_len, answer);
 
-	switch (dns_answer_type(dname_len, answer)) {
+	switch (*type) {
 	case DNS_RR_TYPE_A:
 	case DNS_RR_TYPE_AAAA:
 		set_dns_msg_response(dns_msg, DNS_RESPONSE_IP, pos, len);

--- a/subsys/net/lib/dns/dns_pack.h
+++ b/subsys/net/lib/dns/dns_pack.h
@@ -276,10 +276,12 @@ int dns_msg_pack_qname(uint16_t *len, uint8_t *buf, uint16_t size,
  * @param dname_ptr An index to the previous CNAME. For example for the
  *        first answer, ptr must be 0x0c, the DNAME at the question.
  * @param ttl TTL answer parameter.
+ * @param type Answer type parameter.
  * @retval 0 on success
  * @retval -ENOMEM on error
  */
-int dns_unpack_answer(struct dns_msg_t *dns_msg, int dname_ptr, uint32_t *ttl);
+int dns_unpack_answer(struct dns_msg_t *dns_msg, int dname_ptr, uint32_t *ttl,
+		      enum dns_rr_type *type);
 
 /**
  * @brief Unpacks the header's response.

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -443,8 +443,11 @@ int dns_validate_msg(struct dns_resolve_context *ctx,
 	answer_ptr = DNS_QUERY_POS;
 	items = 0;
 	server_idx = 0;
+	enum dns_rr_type answer_type = DNS_RR_TYPE_INVALID;
+
 	while (server_idx < dns_header_ancount(dns_msg->msg)) {
-		ret = dns_unpack_answer(dns_msg, answer_ptr, &ttl);
+		ret = dns_unpack_answer(dns_msg, answer_ptr, &ttl,
+					&answer_type);
 		if (ret < 0) {
 			ret = DNS_EAI_FAIL;
 			goto quit;
@@ -468,10 +471,10 @@ int dns_validate_msg(struct dns_resolve_context *ctx,
 				goto quit;
 			}
 
+		query_known:
 			if (ctx->queries[*query_idx].query_type ==
 							DNS_QUERY_TYPE_A) {
-				if (net_sin(&info.ai_addr)->sin_family ==
-							AF_INET6) {
+				if (answer_type != DNS_RR_TYPE_A) {
 					ret = DNS_EAI_ADDRFAMILY;
 					goto quit;
 				}
@@ -485,8 +488,7 @@ int dns_validate_msg(struct dns_resolve_context *ctx,
 
 			} else if (ctx->queries[*query_idx].query_type ==
 							DNS_QUERY_TYPE_AAAA) {
-				if (net_sin6(&info.ai_addr)->sin6_family ==
-							AF_INET) {
+				if (answer_type != DNS_RR_TYPE_AAAA) {
 					ret = DNS_EAI_ADDRFAMILY;
 					goto quit;
 				}
@@ -527,8 +529,6 @@ int dns_validate_msg(struct dns_resolve_context *ctx,
 
 			src = dns_msg->msg + dns_msg->response_position;
 			memcpy(addr, src, address_size);
-
-		query_known:
 			ctx->queries[*query_idx].cb(DNS_EAI_INPROGRESS, &info,
 					ctx->queries[*query_idx].user_data);
 			items++;


### PR DESCRIPTION
Fixed mutli-IP DNS resolution as previously the same IP address was
used to populate all AI entries and added DNS_RESOLVER_AI_MAX_ENTRIES
config entry to define max number of IP addresses per DNS name to be
handled.