### PR TITLE
net: lwm2m: Send event on failed reg update

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -362,8 +362,9 @@ static int do_update_reply_cb(const struct coap_packet *response,
 	LOG_ERR("Failed with code %u.%u. Retrying registration",
 		COAP_RESPONSE_CODE_CLASS(code),
 		COAP_RESPONSE_CODE_DETAIL(code));
-	set_sm_state(ENGINE_DO_REGISTRATION);
 
+	set_sm_state(ENGINE_DO_REGISTRATION);
+	client.event_cb(client.ctx, LWM2M_RD_CLIENT_EVENT_REG_UPDATE_FAILURE);
 	return 0;
 }
 


### PR DESCRIPTION
Make a sequential call client event_cb with
LWM2M_RD_CLIENT_EVENT_REG_UPDATE_FAILURE when getting a 4.* response on
a registration update request. This allows the application to react on
this and take appropriate action. For instance, backoff.
