### PR TITLE
net: lwm2m: Made pmin and pmax attributes optional

### DIFF
--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -162,7 +162,7 @@ config LWM2M_SECURITY_KEY_SIZE
 
 config LWM2M_SERVER_DEFAULT_PMIN
 	int "Default server record PMIN"
-	default 10
+	default 0
 	help
 	  Default minimum amount of time in seconds the client must wait
 	  between notifications.  If a resource has to be notified during this
@@ -171,7 +171,7 @@ config LWM2M_SERVER_DEFAULT_PMIN
 
 config LWM2M_SERVER_DEFAULT_PMAX
 	int "Default server record PMAX"
-	default 60
+	default 0
 	help
 	  Default maximum amount of time in seconds the client may wait
 	  between notifications.  When this time period expires a notification

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -521,7 +521,8 @@ static int engine_add_observer(struct lwm2m_message *msg,
 	observe_node_data[i].event_timestamp =
 			observe_node_data[i].last_timestamp;
 	observe_node_data[i].min_period_sec = attrs.pmin;
-	observe_node_data[i].max_period_sec = MAX(attrs.pmax, attrs.pmin);
+	observe_node_data[i].max_period_sec = (attrs.pmax > 0) ? MAX(attrs.pmax, attrs.pmin)
+							       : attrs.pmax;
 	observe_node_data[i].format = format;
 	observe_node_data[i].counter = OBSERVE_COUNTER_START;
 	sys_slist_append(&engine_observer_list,
@@ -4135,19 +4136,23 @@ static int lwm2m_engine_service(void)
 		/*
 		 * manual notify requirements:
 		 * - event_timestamp > last_timestamp
-		 * - current timestamp > last_timestamp + min_period_sec
+		 * - if min_period_sec is set:
+		 *   current timestamp > last_timestamp + min_period_sec
 		 */
 		if (obs->event_timestamp > obs->last_timestamp &&
-		    timestamp > obs->last_timestamp +
-				MSEC_PER_SEC * obs->min_period_sec) {
+		    (obs->min_period_sec == 0 ||
+		     timestamp > obs->last_timestamp +
+				MSEC_PER_SEC * obs->min_period_sec)) {
 			obs->last_timestamp = k_uptime_get();
 			generate_notify_message(obs, true);
 
 		/*
 		 * automatic time-based notify requirements:
-		 * - current timestamp > last_timestamp + max_period_sec
+		 * - if max_period_sec is set:
+		 *   current timestamp > last_timestamp + max_period_sec
 		 */
-		} else if (timestamp > obs->last_timestamp +
+		} else if (obs->max_period_sec > 0 &&
+			   timestamp > obs->last_timestamp +
 				MSEC_PER_SEC * obs->max_period_sec) {
 			obs->last_timestamp = k_uptime_get();
 			generate_notify_message(obs, false);


### PR DESCRIPTION
Cherry-picking this commit from zephyr 

Made the LwM2M engine checks for pmin and pmax optional to adhere to
the LwM2M specificattion. We now first check that pmin and pmax are
actually set. Also changed the default CONFIG values for the attributes
pmin and pmax to 0 to indicate that they are not active by default.

Fixes #34329.

Signed-off-by: Maik Vermeulen <maik.vermeulen@innotractor.com>