### PR TITLE
driver: modem: Fix mux device name comparison

### DIFF
--- a/drivers/modem/modem_iface_uart.c
+++ b/drivers/modem/modem_iface_uart.c
@@ -130,8 +130,8 @@ static bool mux_is_active(struct modem_iface *iface)
 	bool active = false;
 
 #if defined(CONFIG_UART_MUX_DEVICE_NAME)
-	const char *mux_name = CONFIG_UART_MUX_DEVICE_NAME;
-	active = (mux_name == iface->dev->name);
+	active = strncmp(CONFIG_UART_MUX_DEVICE_NAME, iface->dev->name,
+			 sizeof(CONFIG_UART_MUX_DEVICE_NAME) - 1) == 0;
 #endif /* CONFIG_UART_MUX_DEVICE_NAME */
 
 	return active;


### PR DESCRIPTION
CONFIG_UART_MUX_DEVICE_NAME is used as a prefix for the uart muxes
name. Pointer comparison will always return false

Fix #39774

Signed-off-by: Guillaume Lager <g.lager@innoseis.com>