### PR TITLE
Fix: Set mount point to NULL on error in fs_close and fs_read

### DIFF
--- a/subsys/fs/fs.c
+++ b/subsys/fs/fs.c
@@ -158,7 +158,7 @@ int fs_open(struct fs_file_t *zfp, const char *file_name, fs_mode_t flags)
 	rc = zfp->mp->fs->open(zfp, file_name, flags);
 	if (rc < 0) {
 		LOG_ERR("file open error (%d)", rc);
-		return rc;
+		zfp->mp = NULL;
 	}
 
 	return rc;
@@ -179,7 +179,6 @@ int fs_close(struct fs_file_t *zfp)
 	rc = zfp->mp->fs->close(zfp);
 	if (rc < 0) {
 		LOG_ERR("file close error (%d)", rc);
-		return rc;
 	}
 
 	zfp->mp = NULL;

--- a/subsys/net/lib/lwm2m/lwm2m_obj_swmgmt.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_swmgmt.c
@@ -5,8 +5,7 @@
  */
 
 #define LOG_MODULE_NAME net_lwm2m_obj_swmgmt
-#define LOG_LEVEL CONFIG_LWM2MM_LOG_LEVEL_DBG
-
+#define LOG_LEVEL CONFIG_LWM2M_LOG_LEVEL_DBG
 #include <logging/log.h>
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 


### PR DESCRIPTION
Set mp to null in fs_read on failure. 
Do not return early failure in fs_close. This sets mp to NULL.
Fix the typo in lwm2m_obj_swmgmt.c