### PR TITLE
Fix PPP stop delay

### DIFF
--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -591,8 +591,9 @@ registering:
 					DLCI_AT, gsm->at_dev->name);
 			}
 		}
-		modem_cmd_handler_tx_unlock(&gsm->context.cmd_handler);
 	}
+
+	modem_cmd_handler_tx_unlock(&gsm->context.cmd_handler);
 }
 
 static int mux_enable(struct gsm_modem *gsm)

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -345,7 +345,7 @@ static int do_update_reply_cb(const struct coap_packet *response,
 	uint8_t code;
 
 	code = coap_header_get_code(response);
-	LOG_INF("Update callback (code:%u.%u)",
+	LOG_DBG("Update callback (code:%u.%u)",
 		COAP_RESPONSE_CODE_CLASS(code),
 		COAP_RESPONSE_CODE_DETAIL(code));
 
@@ -353,7 +353,7 @@ static int do_update_reply_cb(const struct coap_packet *response,
 	if ((code == COAP_RESPONSE_CODE_CHANGED) ||
 	    (code == COAP_RESPONSE_CODE_CREATED)) {
 		set_sm_state(ENGINE_REGISTRATION_DONE);
-		LOG_INF("Update Done");
+		LOG_DBG("Update Done");
 		return 0;
 	}
 


### PR DESCRIPTION
Modem CMD handler lock is done regardless whether GSM MUX is enabled, while unlock is done only in this case. Starting from the second `gsm_ppp_stop()` call we're always waiting for 10 seconds without any need.