### PR TITLE
stm32 spi: Enable pin control when SPI is idle

### DIFF
--- a/drivers/spi/spi_stm32.c
+++ b/drivers/spi/spi_stm32.c
@@ -1287,6 +1287,11 @@ static int spi_stm32_configure(const struct device *dev,
 		LL_SPI_EnableIOSwap(cfg->spi);
 	}
 #endif
+	if (cfg->alternate_function_gpio_control) {
+		LL_SPI_EnableGPIOControl(cfg->spi);
+	} else {
+		LL_SPI_DisableGPIOControl(cfg->spi);
+	}
 
 	if (SPI_MODE_GET(config->operation) & SPI_MODE_CPOL) {
 		LL_SPI_SetClockPolarity(spi, LL_SPI_POLARITY_HIGH);
@@ -2173,6 +2178,7 @@ static int spi_stm32_init(const struct device *dev)
 			DT_INST_STRING_UPPER_TOKEN(id, st_spi_data_width)),	\
 		.fifo_enabled = SPI_FIFO_ENABLED(id),				\
 		.ioswp = DT_INST_PROP(id, ioswp),				\
+		.alternate_function_gpio_control = DT_INST_PROP(id, alternate_function_gpio_control), \
 		STM32_SPI_IRQ_HANDLER_FUNC(id)					\
 		IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_subghz),	\
 			   (.use_subghzspi_nss =				\

--- a/drivers/spi/spi_stm32.h
+++ b/drivers/spi/spi_stm32.h
@@ -39,6 +39,7 @@ struct spi_stm32_config {
 #endif
 	bool fifo_enabled: 1;
 	bool ioswp: 1;
+	bool alternate_function_gpio_control: 1;
 	bool soft_nss: 1;
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_subghz)
 	bool use_subghzspi_nss: 1;

--- a/dts/bindings/spi/st,stm32-spi-common.yaml
+++ b/dts/bindings/spi/st,stm32-spi-common.yaml
@@ -22,6 +22,14 @@ properties:
     type: boolean
     description: Swap SPI MOSI and MISO pins
 
+  alternate-function-gpio-control:
+    type: boolean
+    description: |
+      When set, the SPI driver will control the SPI GPIOs (e.g. SCK, MOSI, MISO)
+      even when the SPI peripheral is disabled. This can be used to ensure a known
+      state on the SPI lines at all times, which may be required for certain
+      peripherals (e.g. LED strips) that are sensitive to line states during idle.
+
   st,spi-data-width:
     type: string
     enum:


### PR DESCRIPTION
The MOSI of the STM32H5 SPI controller is floating when the SPI is idle. As we use a pull-up on that pin, this causes an idle-high voltage on the MOSI pin.

We use the MOSI pin for control of WS2812 LEDs, and they requires an idle-low voltage.

Add a devicetree setting 'alternate-function-gpio-control' so the SPI controller keeps control of the MOSI pin also between transmissions. This enables the AFCNTR bit in the STM32 SPI controller, via the LL_SPI_EnableGPIOControl() HAL function.